### PR TITLE
Clarifications to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policies and Procedures
 
-This document outlines security procedures and policies for the all of the PrivacyTools repositories and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
+This document outlines security procedures and policies for all PrivacyTools repositories and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
 
 ## Reporting a Bug
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policies and Procedures
 
-This document outlines security procedures and policies for all PrivacyTools repositories and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
+This document outlines security procedures and policies for all repositories owned by PrivacyTools and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
 
 ## Reporting a Bug
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policies and Procedures
 
-This document outlines security procedures and policies for the `privacytools.io` repository/code and all services hosted by privacytools.io, such as Mastodon, Matrix, Riot, et cetera.
+This document outlines security procedures and policies for the all of the PrivacyTools repositories and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
 
 ## Reporting a Bug
 
@@ -32,4 +32,4 @@ Additionally, if user data was directly affected or compromised, we will inform 
 
 ## Comments on this Policy
 
-Please open a Pull Request or Issue if you would like to discuss any changes to this policy.
+Please open a [Pull Request](https://github.com/privacytoolsIO/.github/pulls) or [Issue](https://github.com/privacytoolsIO/.github/issues) if you would like to discuss any changes to this policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policies and Procedures
 
-This document outlines security procedures and policies for all repositories owned by PrivacyTools and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
+This document outlines security procedures and policies for all non-forked repositories owned by PrivacyTools and all services hosted by PrivacyTools, such as Mastodon, Matrix, Riot, et cetera.
 
 ## Reporting a Bug
 
@@ -10,7 +10,7 @@ Report any security bugs by emailing the services administrator at [admin@privac
 
 The administrative team will acknowledge your message within 48 hours, and will provide a detailed response within 72 hours detailing the next steps for handling your report. After our initial reply we will make every effort to keep you informed of the progress towards a fix and announcement, and we may ask for additional information or guidance.
 
-Please report any security bugs in third-party projects to the person or team maintaining that project.
+Please report any security bugs in third-party projects to the person or team maintaining that project. Examples of third-party projects include our Searx instance (search.privacytools.io) and our Riot instance (riot.privacytools.io), as we do not actively maintain those projects.
 
 The following are out of scope and should **not** be attacked/performed:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Report any security bugs by emailing the services administrator at [admin@privac
 
 The administrative team will acknowledge your message within 48 hours, and will provide a detailed response within 72 hours detailing the next steps for handling your report. After our initial reply we will make every effort to keep you informed of the progress towards a fix and announcement, and we may ask for additional information or guidance.
 
-Please report any security bugs in third-party projects to the person or team maintaining that project. Examples of third-party projects include our Searx instance (search.privacytools.io) and our Riot instance (riot.privacytools.io), as we do not actively maintain those projects.
+Please report any security bugs in third-party projects to the person or team developing that project. Examples of third-party projects include our Searx instance (search.privacytools.io) and our Riot instance (riot.privacytools.io), as we do not actively assist in developing those projects.
 
 The following are out of scope and should **not** be attacked/performed:
 


### PR DESCRIPTION
Being in the .github repo means that this same policy will be available in the
Security section of all repos owned by the PrivacyTools organization on GH.
This means that we should
* state that it's not just for the specific privacytools.io website repository,
* direct anyone looking comment on the security policy towards the 
repository where SECURITY.md lives.

Also, this PR addresses the rebranding (privacytools.io to PrivacyTools)